### PR TITLE
Define a sentence as a word* without a NEW_LINE at the end.

### DIFF
--- a/src/main/antlr/Asciidoc.g4
+++ b/src/main/antlr/Asciidoc.g4
@@ -9,7 +9,7 @@ document        : header preamble body ;
 // NOTE: "You cannot have a revision line without an author line."
 header          : document_title author_line? revision_line? attributes? NEW_LINE  ;
 
-document_title  : '=' phrase NEW_LINE ;
+document_title  : '=' sentence NEW_LINE ;
 author_line     : CHARS CHARS '<' email '>' NEW_LINE ;
  // based on example v1.0, 2014-01-01
 revision_line   : 'v' NUMBERS '.' NUMBERS NEW_LINE ;
@@ -32,8 +32,9 @@ target          : IDENTIFIER ;
 param           : word ;
 
 // See http://www.regular-expressions.info/email.html for a better representation of an email
-email           : CHARS '@' CHARS '.' (CHARS) ; // 
-phrase          : word* NEW_LINE ;
+email           : CHARS '@' CHARS '.' (CHARS) ; //
+sentence        : word* ;
+phrase          : word* NEW_LINE;
 special_characters : '$' | '/' | '-'; // Temporal fix to avoid failing on URLs
 attribute_substitution :  '{' preset_attributes '}' ;
 // See http://asciidoctor.org/docs/user-manual/#built-in-data-attributes

--- a/src/main/antlr/Asciidoc.g4
+++ b/src/main/antlr/Asciidoc.g4
@@ -10,12 +10,13 @@ document        : header preamble body ;
 header          : document_title author_line? revision_line? attributes? NEW_LINE  ;
 
 document_title  : '=' sentence NEW_LINE ;
-author_line     : CHARS CHARS '<' email '>' NEW_LINE ;
+author_line     : CHARS CHARS* email_address* NEW_LINE ;
+email_address   :  '<' email '>' ;
  // based on example v1.0, 2014-01-01
 revision_line   : 'v' NUMBERS '.' NUMBERS NEW_LINE ;
 attributes      : ':' '!'? atribute_name '!'? ':' atribute_value NEW_LINE ;
 atribute_name   : word ;
-atribute_value  : ANYCHAR ;
+atribute_value  : ANY_CHAR ;
 
 preamble        : paragraph  ;
 paragraph       : phrase* NEW_LINE;
@@ -32,7 +33,7 @@ target          : IDENTIFIER ;
 param           : word ;
 
 // See http://www.regular-expressions.info/email.html for a better representation of an email
-email           : CHARS '@' CHARS '.' (CHARS) ; //
+email           : CHARS '@' CHARS '.' CHARS ; //
 sentence        : word* ;
 phrase          : word* NEW_LINE;
 special_characters : '$' | '/' | '-'; // Temporal fix to avoid failing on URLs
@@ -48,7 +49,7 @@ word            : CHARS PUNCTUATION? ;
 CHARS           : [0-9a-zA-Z]+ ;
 IDENTIFIER      : [a-zA-Z]+ ;
 //BEGIN_PUNCTUATION : [¿¡] ; // Some languages have beginning punctuation (e.g. Spanish)
-PUNCTUATION     : [.:,;] ;
+PUNCTUATION     : '.' ;//[.:,;] ;
 //word            : ~[\n\t ]+ ;
-ANYCHAR         : ~[\n\t ]+ ; // PH
+ANY_CHAR         : ~[\n\t ] ; // PH
 WS              : [ \t\r]+ -> skip ;

--- a/src/main/antlr/Asciidoc.g4
+++ b/src/main/antlr/Asciidoc.g4
@@ -12,6 +12,8 @@ header          : document_title author_line? revision_line? attributes? NEW_LIN
 document_title  : '=' sentence NEW_LINE ;
 author_line     : CHARS CHARS* email_address* NEW_LINE ;
 email_address   :  '<' email '>' ;
+email           : CHARS '@' CHARS '.' CHARS ; //
+
  // based on example v1.0, 2014-01-01
 revision_line   : 'v' NUMBERS '.' NUMBERS NEW_LINE ;
 attributes      : ':' '!'? atribute_name '!'? ':' atribute_value NEW_LINE ;
@@ -19,12 +21,13 @@ atribute_name   : word ;
 atribute_value  : ANY_CHAR ;
 
 preamble        : paragraph  ;
-paragraph       : phrase* NEW_LINE;
+paragraph       : phrase+ NEW_LINE;
+phrase          : word+ '.'? NEW_LINE? | properties NEW_LINE | predef_attributes NEW_LINE ;
 
 body            : section* ;
 section         : section_header section_body ;
-section_header  : '=='+ phrase ;
-section_body    : phrase* NEW_LINE ;
+section_header  : '=='+ phrase NEW_LINE;
+section_body    : phrase+ NEW_LINE ;
 
 inline_macro    : method ':' target '[' params ']' ;
 params          : param* ;
@@ -33,23 +36,24 @@ target          : IDENTIFIER ;
 param           : word ;
 
 // See http://www.regular-expressions.info/email.html for a better representation of an email
-email           : CHARS '@' CHARS '.' CHARS ; //
 sentence        : word* ;
-phrase          : word* NEW_LINE;
 special_characters : '$' | '/' | '-'; // Temporal fix to avoid failing on URLs
 attribute_substitution :  '{' preset_attributes '}' ;
 // See http://asciidoctor.org/docs/user-manual/#built-in-data-attributes
 preset_attributes : 'author' | 'email' | 'backend' | 'doctitle' ;
+word            : CHARS PUNCTUATION? | CHARS SPLPUNCTUATION CHARS;
+predef_attributes: '{' (word | word special_characters word) '}';
+properties       : word+ '::' (predef_attributes | word+) ;
 
 NEW_LINE        : '\n' ;
 LINE_BREAK      : '+' ;
 NUMBERS          : [0-9]+ ;
 
-word            : CHARS PUNCTUATION? ;
 CHARS           : [0-9a-zA-Z]+ ;
 IDENTIFIER      : [a-zA-Z]+ ;
 //BEGIN_PUNCTUATION : [¿¡] ; // Some languages have beginning punctuation (e.g. Spanish)
-PUNCTUATION     : '.' ;//[.:,;] ;
+PUNCTUATION     : [,;?:] ;
+SPLPUNCTUATION  : ['_] ;
 //word            : ~[\n\t ]+ ;
 ANY_CHAR         : ~[\n\t ] ; // PH
 WS              : [ \t\r]+ -> skip ;


### PR DESCRIPTION
Using 'phrase' for the header causes errors because the phrase itself
has a NEW_LINE and the header was a phrase followed by a NEW_LINE. So,
header became word\* NEW_LINE NEW_LINE which is incorrect. Now, header
is sentence NEW_LINE, which is then word\* NEW_LINE.
